### PR TITLE
Fix migrate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ CREATE DATABASE lily_test;
 Migrate the database to the latest schema:
 
 ```sh
-lily --db "postgres://username@localhost/lily_test?sslmode=disable" migrate --latest
+lily migrate --db "postgres://username@localhost/lily_test?sslmode=disable" --latest
 ```
 
 Run the tests:


### PR DESCRIPTION
the `--db` flag is a part of `lily migrate` - not lily

the command as it fails. 

Visor version:v0.7.7+16-gb048a53